### PR TITLE
Add LoginPage Class and Update Tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,3 +20,8 @@ jobs:
         run: npm ci
       - name: Run tests 🎭
         run: npx playwright test --project=e2e-chromium
+        env:
+          EMAIL: ${{ secrets.EMAIL }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+          HTTP_CREDENTIALS_USERNAME: ${{ secrets.HTTP_CREDENTIALS_USERNAME }}
+          HTTP_CREDENTIALS_PASSWORD: ${{ secrets.HTTP_CREDENTIALS_PASSWORD }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,9 +14,9 @@ export default defineConfig({
     globalSetup: './globalSetup',
     testDir: './tests',
     /* Run tests in files in parallel */
-    fullyParallel: false,
-    workers: 3,
-    maxFailures: 10,
+    fullyParallel: true,
+    workers: process.env.CI ? 3 : 5,
+    maxFailures: process.env.CI ? 10 : undefined,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */

--- a/project/pages/LoginPage.ts
+++ b/project/pages/LoginPage.ts
@@ -1,0 +1,42 @@
+import {expect, Page} from "@playwright/test";
+
+export class LoginPage {
+    private readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    public async navigateTo(sting: string) {
+        await this.page.goto(sting);
+    }
+
+    public async clickSignInButton() {
+        await this.page.getByRole('button', {name: 'Sign In'}).click();
+    }
+
+    public async fillEmail(email: string) {
+        await this.page.getByLabel('Email').fill(email);
+    }
+
+    public async fillPassword(password: string) {
+        await this.page.getByLabel('Password').fill(password);
+    }
+
+    public async clickRememberMeCheckbox() {
+        await this.page.getByLabel('Remember me').click();
+    }
+
+    public async clickLoginButton() {
+        await this.page.getByRole('button', {name: 'Login'}).click();
+    }
+
+    public async verifyProfileButtonVisible() {
+        await expect(this.page.getByRole('button', {name: 'My profile'})).toBeVisible();
+    }
+
+    public async saveSession() {
+        const authFile = '.auth/user.json';
+        await this.page.context().storageState({path: authFile});
+    }
+}

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,24 +1,27 @@
-import {expect, test as setup, test} from '@playwright/test';
-const authFile = '.auth/user.json';
+import {test as setup, test} from '@playwright/test';
+import {LoginPage} from "../project/pages/LoginPage";
 
 setup('authenticate', async ({page}) => {
+    const loginPage = new LoginPage(page);
+
     await test.step("Navigate to QAuto site", async () => {
-        await page.goto('/');
+        await loginPage.navigateTo('/');
     });
+
     await test.step("Click to Sign in button", async () => {
-        await page.getByRole('button', {name: 'Sign In'}).click();
+        await loginPage.clickSignInButton();
     });
+
     await test.step("Fill Email, Password, click remember me, ", async () => {
-        await page.getByLabel('Email').fill(process.env.EMAIL);
-        await page.getByLabel('Password').fill(process.env.PASSWORD);
-        await page.getByLabel('Remember me').click();
+        await loginPage.fillEmail(process.env.EMAIL);
+        await loginPage.fillPassword(process.env.PASSWORD);
+        await loginPage.clickRememberMeCheckbox();
     });
+
     await test.step("Click to Login button", async () => {
-        await page.getByRole('button', {name: 'Login'}).click();
+        await loginPage.clickLoginButton();
     });
 
-    await page.waitForURL('https://qauto.forstudy.space/panel/garage');
-    await expect(page.getByRole('button', {name: 'My profile'})).toBeVisible();
-
-    await page.context().storageState({path: authFile});
+    await loginPage.verifyProfileButtonVisible();
+    await loginPage.saveSession();
 });


### PR DESCRIPTION
Created a new LoginPage class in the `project/pages` directory, extracting all login related interactions from the auth.setup.ts script to this new class. This makes the auth.setup.ts script cleaner by abstracting away all the details of logging in. Also updated environment variables for the GitHub workflows to securely store credentials. Finally, improved playwright test configuration by enabling parallel execution and adjusting worker and maxFailures settings based on whether the tests are run in CI or not.